### PR TITLE
Update Q12-netpol-deny-all.md

### DIFF
--- a/7-mock-exam-questions/Q12-netpol-deny-all.md
+++ b/7-mock-exam-questions/Q12-netpol-deny-all.md
@@ -41,6 +41,7 @@ spec:
     - podSelector:
         matchLabels:
           app: backend ## use the same label as specified on the 2nd spec
+      namespaceSelector: {}
     ports:
     - protocol: TCP
       port: 6379


### PR DESCRIPTION
Empty {} namespace selector required otherwise it selects the pods with matching labels in the namespace where network policy created instead of pods with matching labels in all namespaces